### PR TITLE
Add check for KMT handle support

### DIFF
--- a/source/VulkanInterop.cs
+++ b/source/VulkanInterop.cs
@@ -173,7 +173,7 @@ public unsafe class VulkanInterop
         return false;
     }
 
-    private bool CheckExternalImageHandleType(PhysicalDevice physicalDevice)
+    private bool CheckExternalImageHandleType(PhysicalDevice physicalDevice, Format targetFormat)
     {
         var externalFormatInfo = new PhysicalDeviceExternalImageFormatInfo
         (
@@ -183,7 +183,7 @@ public unsafe class VulkanInterop
         var formatInfo = new PhysicalDeviceImageFormatInfo2
         (
             pNext: &externalFormatInfo,
-            format: Format.R8G8B8A8Unorm,
+            format: targetFormat,
             type: ImageType.Type2D,
             tiling: ImageTiling.Optimal,
             usage: ImageUsageFlags.ColorAttachmentBit
@@ -552,7 +552,7 @@ public unsafe class VulkanInterop
 
             if (CheckGraphicsQueue(physicalDevice, ref queueIndex)
                 && CheckExternalMemoryExtension(physicalDevice)
-                && CheckExternalImageHandleType(physicalDevice))
+                && CheckExternalImageHandleType(physicalDevice, targetFormat))
             {
                 this.physicalDevice = physicalDevice;
                 break;


### PR DESCRIPTION
Adds a check during physical device selection to ensure the device supports KMT handles for external/shared images. Now the `"Suitable device not found"` exception is thrown if KMT handles aren't supported.

For https://github.com/malstraem/vulkan-interop-directx/issues/2